### PR TITLE
Improve ADS client handling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ in perpetuity.
 
 ## Overview
 
-This is a simle example of fetching and processing data from a PLC structure variable, and subsequently transforming this data into a PDF document. The core functionality involves accessing a specific PLC variable via its name, attempting to apply the contents of this variable to a predefined template, and, upon successful integration, generating a PDF output. 
+This is a simple example of fetching and processing data from a PLC structure variable, and subsequently transforming this data into a PDF document. The core functionality involves accessing a specific PLC variable via its name, attempting to apply the contents of this variable to a predefined template, and, upon successful integration, generating a PDF output.
 
 ## Screenshot
 
@@ -56,7 +56,7 @@ There's a copy of template.json in the template folder. Make sure to use it as t
 ### Run the program
 The program takes the following arguments:
 
-1. pdfPath : The path to the output PDF file.|
+1. pdfPath : The path to the output PDF file.
 2. templatePath: the path to the JSON template file.
 3. variable: the name of the PLC structure variable to read.
 4. netId (optional): the ADS Net ID of the PLC, defaults to 127.0.0.1.1.1.

--- a/src/adsReadSymbol.js
+++ b/src/adsReadSymbol.js
@@ -1,18 +1,21 @@
 const ads = require("ads-client");
 
 module.exports = class ADSReadSymbol {
-  static async getValueFromClient(VariableName, NetId, Port) {
-    const client = ADSReadSymbol.createAdsClient(NetId, Port);
+  static async getValueFromClient(variableName, netId, port) {
+    const client = ADSReadSymbol.createAdsClient(netId, port);
     await client.connect();
-    const response = await client.readSymbol(VariableName);
-    await client.disconnect();
-    return response.value;
+    try {
+      const response = await client.readSymbol(variableName);
+      return response.value;
+    } finally {
+      await client.disconnect();
+    }
   }
 
-  static createAdsClient(NetId, Port) {
+  static createAdsClient(netId, port) {
     return new ads.Client({
-      targetAmsNetId: NetId,
-      targetAdsPort: Port,
+      targetAmsNetId: netId,
+      targetAdsPort: port,
     });
   }
 };


### PR DESCRIPTION
## Summary
- ensure ADS client disconnects even if read fails
- fix typos and formatting in README

## Testing
- `node -c src/adsReadSymbol.js`
- `node -c src/pdfCreator.js`
- `node -c app.js`
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68744639dccc8330a2f39e6e9d4733b2